### PR TITLE
don't rely on RELEASE.json for versioning

### DIFF
--- a/.github/workflows/build-binary-package.yml
+++ b/.github/workflows/build-binary-package.yml
@@ -17,11 +17,6 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    - name: Check tag == json version
-      run: |
-        jsonver=$(cat RELEASE.json | jq -r .Version)
-        lasttag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)'  | cut -d '/' -f3)
-        if [ ${jsonver} != ${lasttag} ] ; then echo "version mismatch : ${jsonver} in json, ${lasttag} in git" ; exit 2 ; else echo "${jsonver} == ${lasttag}" ; fi
     - name: Build the binaries
       run: make release
     - name: Upload to release

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Go parameters
-export BUILD_VERSION=$(shell cat RELEASE.json | jq -r .Version)
+BUILD_VERSION?="$(shell git for-each-ref --sort=-v:refname --count=1 --format '%(refname)'  | cut -d '/' -f3)"
 GOCMD=go
 GOBUILD=GOPRIVATE="github.com/crowdsecurity" $(GOCMD) build
 GOCLEAN=$(GOCMD) clean

--- a/RELEASE.json
+++ b/RELEASE.json
@@ -1,4 +1,3 @@
 {
-    "Version": "v0.0.1",
     "CodeName": "road2beta"
 }


### PR DESCRIPTION
update actions to get version from git tag rather than JSON file